### PR TITLE
Enable XhciPortLimit

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -494,7 +494,7 @@
                 <key>ThirdPartyDrives</key>
                 <false/>
                 <key>XhciPortLimit</key>
-                <false/>
+                <true/>
             </dict>
             <key>Scheme</key>
             <dict>


### PR DESCRIPTION
See https://github.com/hackintosh-club/MAG-B660M-MORTAR-WIFI-DDR4-OpenCore/commit/d531d9846d5903827c1a7b17230c0653ea285555#commitcomment-124502352